### PR TITLE
Improve Categorical Prediction Speed

### DIFF
--- a/m2cgen/interpreters/java/interpreter.py
+++ b/m2cgen/interpreters/java/interpreter.py
@@ -42,7 +42,7 @@ class JavaInterpreter(ToCodeInterpreter,
             top_cg.add_package_name(self.package_name)
 
         top_cg.add_code_line("import java.util.Arrays;")
-        top_cg.add_code_line("import java.util.HashSet;")
+        top_cg.add_code_line("import java.util.BitSet;")
 
         with top_cg.class_definition(self.class_name):
 
@@ -53,7 +53,7 @@ class JavaInterpreter(ToCodeInterpreter,
             self.process_subroutine_queue(top_cg)
 
             if self.static_declarations:
-                top_cg.add_code_line("static HashSet<Integer> {};".format(','.join([name for name, _ in self.static_declarations])))
+                top_cg.add_code_line("static MinBitset {};".format(','.join([name for name, _ in self.static_declarations])))
 
             top_cg.add_code_line("static {")
             top_cg.increase_indent()

--- a/m2cgen/interpreters/java/linear_algebra.java
+++ b/m2cgen/interpreters/java/linear_algebra.java
@@ -19,15 +19,47 @@ public static double[] mulVectorNumber(double[] v1, double num) {
 }
 
 
-public static boolean contains(HashSet<Integer> v1, double featureRef) {
+public static boolean contains(MinBitset v1, double featureRef) {
     return v1.contains((int) featureRef);
 }
 
-public static HashSet<Integer> parseIntArray(String input) {
+public static MinBitset parseIntArray(String input) {
     String[] strings = input.split(",");
-    HashSet<Integer> numbers = new HashSet<Integer>(strings.length);
+    int[] numbers = new int[strings.length];
     for (int i = 0; i < strings.length; i++) {
-        numbers.add(Integer.parseInt(strings[i]));
+        numbers[i] = Integer.parseInt(strings[i]);
     }
-    return numbers;
+    return new MinBitset(numbers);
+}
+
+
+public static class MinBitset {
+
+    private final int offset;
+    private final BitSet set;
+
+    // Inspired by TreeLite which uses bitmaps to deal with categorical variables. This is ~3x faster vs HashSet<Integer>
+    // https://github.com/dmlc/treelite/blob/46c8390aed4491ea97a017d447f921efef9f03ef/src/compiler/common/categorical_bitmap.h#L22-L28
+    public MinBitset(int[] input) {
+        Arrays.sort(input);
+
+        // offset the values by the minimum. this helps with memory usage for ranges that start high
+        offset = input[0];
+        int max = input[input.length - 1];
+
+        set = new BitSet(max - offset);
+
+        for (int value : input) {
+            int categorical = value - offset;
+            set.set(categorical);
+        }
+    }
+
+    public boolean contains(int value) {
+        value -= offset;
+        if (value > -1) {
+            return set.get(value);
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Change the categorical lookup to use a BitSet instead of HashSet. 
This is ~3x faster at the cost of some additional memory

The java BitSet class is bitmap implementation that uses an array of long to pack 64 values into a single value (long = 64 bits). So the memory required for each BitSet is `(max(categorical) - min(categorical)) / 64 * 8` bytes

The lookup operation is constant time (~3 operations) and optimized using bitshifts instead of normal instructions

If you were to write an implementation from scratch it would probably look something like this
```java
// create bitmask
bitmap = new long[numRequired];

for (int i = 0; i < input.length; i++) {
       int cat = input[i] - min;
       int bitmapIdx = cat / 64;
       int offset = cat % 64;
       bitmap[bitmapIdx] |= (1 << offset);
}


public boolean contains(int value) {
        value -= min;
        int bitmapIdx = value / 64; // each index is 64 values, this gives us the array position
        // actually implmented as value >> 6;

        int offset = value % 64; // modulo to calculate the bitmask position
        // could be implemented as int d = 1 << 6; int offset = value & (d - 1) but isn't necessary
        // since it is equivalent to the bitshift we do later when calculating the mask; this gets removed

        if (bitmapIdx >= 0 && bitmapIdx < bitmap.length) { // bounds check to handle items outside the array
            return (bitmap[bitmapIdx] & (1L << offset)) != 0; // calculate mask and bitwise AND to check if its set
        }
        return false;
}
```


One thing to note about this change, we should aim to keep the ranges of categorical small (start at 0, monotonically increasing) so that we minimize wasted memory. 


@Zocdoc/search 